### PR TITLE
Use cmake 2.8 instead of 3.5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Pass any cmake options this way:
+
+# ./build.sh -DFOGLAMP_INSTALL=/some_path/FogLAMP
+#
+
+os_name=`(grep -o '^NAME=.*' /etc/os-release | cut -f2 -d\" | sed 's/"//g')`
+os_version=`(grep -o '^VERSION_ID=.*' /etc/os-release | cut -f2 -d\" | sed 's/"//g')`
+
+if [[ ( $os_name == *"Red Hat"* || $os_name == *"CentOS"* ) &&  $os_version == *"7"* ]]; then
+	if [ -f build_rhel.sh ]; then
+		echo "Custom build for platform is ${os_name}, Version: ${os_version}"
+		./build_rhel.sh $@
+	fi
+elif apt --version 2>/dev/null; then
+	if [ -f build_deb.sh ]; then
+		echo "Custom build for platform is ${os_name}, Version: ${os_version}"
+		./build_deb.sh $@
+	fi
+else
+	echo "Custom build script not yet implemented for platform ${os_name}, Version: ${os_version}"
+fi

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Pass any cmake options this way:
+
+# ./build_deb.sh -DFOGLAMP_INSTALL=/some_path/FogLAMP
+
+mkdir build
+cd build/
+cmake $@ ..
+make

--- a/build_rhel.sh
+++ b/build_rhel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Pass any cmake options this way:
+
+# ./build_rhel.sh -DFOGLAMP_INSTALL=/some_path/FogLAMP
+
+source scl_source enable devtoolset-7
+export CC=$(scl enable devtoolset-7 "command -v gcc")
+export CXX=$(scl enable devtoolset-7 "command -v g++")
+
+mkdir build
+cd build/
+cmake $@ ..
+make

--- a/requirements.sh
+++ b/requirements.sh
@@ -33,9 +33,11 @@ if [[ ( $os_name == *"Red Hat"* || $os_name == *"CentOS"* ) &&  $os_version == *
 	echo Installing boost components
 	sudo yum install -y boost-filesystem
 	sudo yum install -y boost-program-options
+	sudo yum install llvm-toolset-7-clang
 	source scl_source enable devtoolset-7
 	export CC=/opt/rh/devtoolset-7/root/usr/bin/gcc
 	export CXX=/opt/rh/devtoolset-7/root/usr/bin/g++
+	source scl_source enable llvm-toolset-7
 elif apt --version 2>/dev/null; then
 	echo Installing boost components
 	sudo apt install -y libboost-filesystem-dev
@@ -66,7 +68,8 @@ if [ ! -d "${directory}/opendnp3" ]; then
 	#	mv cpp/lib/include/opendnp3/app/OctetData.h.$$ cpp/lib/include/opendnp3/app/OctetData.h
 
 	# OpenDNP claims it needs 3.8 of cmake, but actually it doesn't
-	sed -i CMakeLists.txt -e 's/VERSION 3.8/VERSION 3.5/'
+	sed -i CMakeLists.txt -e 's/VERSION 3.8/VERSION 2.8/'
+	sed -i CMakeLists.txt -e 's/opendnp3 VERSION .*/opendnp3\)/'
 	mkdir build
 	cd build
 	echo Building opendnp3 static library ...


### PR DESCRIPTION
For CentOS/RHEL 7 cmake 2.8 is the latest available version.

Also added clang support in CentOS/RHEL 7

Note:

- This fix is valid as we are using "release-2.x" od the library

- development version of opendnp3 library in https://github.com/dnp3/opendnp3/tree/develop
will need cmake 3.11
